### PR TITLE
added a python3 serverless example for ethereum

### DIFF
--- a/python-ethereum/handler.py
+++ b/python-ethereum/handler.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3.9
+# -*- coding: utf-8 -*-
+
+import sys, secrets, time, json, msgpack, argon2, base64
+import string
+
+from eth_account import Account
+
+def handler(event, context):
+    """Handle a request to the Lyra serverless funciton
+    Args:
+        event (dict): request params
+        context (dict): function call metadata
+    
+    Description:
+        * generates a private key from true random numbers
+        * attaches 0x to make the hexadecimal look like an address
+        * computes an ethereum address
+        * calculates a unix timestamp
+        * transforms into subbinary messagepack serialization
+        * creates an argon2 hash of the serialization with salt 'scaleway'
+        * stores hashsum, payload, and obfuscated salt into a json
+        * theoretic concept of signing a data structure with a mutually known secret
+    
+    """
+
+    _salt_ = str(base64.b64decode(b'c2NhbGV3YXk=')) # technically argon2 is not sha1 ... 
+    _binarysecret_ = 0x01
+    priv = secrets.token_hex(32)
+    private_key = "0x" + priv
+    acct = Account.from_key(private_key)
+
+    payload = {
+        'privkey'   : private_key,
+        'address'   : acct.address,
+        'timestamp' : time.time(),
+    }
+
+    string = msgpack.packb(payload, use_bin_type=True)
+    hash = argon2.argon2_hash(string, _salt_)
+
+    data = {
+        'hashsum':    str(base64.b64encode(hash)),
+        'payload':    payload,
+        'transport':  str(base64.b64encode(bytes(_salt_, "utf-8"))),
+    }
+
+    return {
+        "body": json.dumps(data), 
+        "headers": {
+            "Content-Type": ["text/json"],
+        }
+    }

--- a/python-ethereum/package.json
+++ b/python-ethereum/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "python-ethereum",
+  "version": "0.0.1",
+  "main": "handler.py",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "ethereum",
+    "blockchain",
+    "crypto",
+    "web"
+  ],
+  "author": "",
+  "license": "Lyra",
+  "devDependencies": {
+    "serverless-scaleway-functions": "^0.4.4"
+  },
+  "description": "Ethereum Wallet Generator and Basic Cryptography"
+}

--- a/python-ethereum/serverless.yml
+++ b/python-ethereum/serverless.yml
@@ -1,0 +1,26 @@
+service: generate_wallet
+configValidationMode: off
+provider:
+  name: scaleway
+  runtime: python311 # Available python runtimes are listed in documentation
+  # Global Environment variables - used in every functions
+  env:
+    test: test
+  svwProject: f8983157-9a25-4661-89b4-a862292862d9
+
+plugins:
+  - serverless-scaleway-functions
+
+package:
+  patterns:
+    - '!node_modules/**'
+    - '!.gitignore'
+    - '!.git/**'
+
+functions:
+  first:
+    handler: handler.handle
+    # description: ""
+    # Local environment variables - used only in given function
+    env:
+      local: local


### PR DESCRIPTION
- generates an ethereum private key and address, in a self-signed data structure, with a base64 secret 'scaleway'