### PR TITLE
fix command for list namespace in readme and script environment variables

### DIFF
--- a/functions/serverless-gateway-python/README.md
+++ b/functions/serverless-gateway-python/README.md
@@ -12,7 +12,7 @@ This example uses:
 
 Deploy the serverless gateway as a container following the Serverless Gateway project instructions.
 
-Make sure to export your gateway base URL (`GATEWAY_HOST`) and an authentication token (`TOKEN`)
+*Make sure to export your gateway base URL (`GATEWAY_HOST`) and an authentication token (`TOKEN`)*
 
 ## Running 
 
@@ -29,7 +29,7 @@ scw-serverless deploy app.py --gateway-url https://${GATEWAY_HOST} --gateway-api
 
 You can use:
 ```
-./list_gateway_endpoints.sh
+./scripts/list_gateway_endpoints.sh
 ```
 
 ### Call your function via its route

--- a/functions/serverless-gateway-python/scripts/add_function_to_gateway.sh
+++ b/functions/serverless-gateway-python/scripts/add_function_to_gateway.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-curl -X POST https://${GATEWAY_URL}/scw \
-             -H 'X-Auth-Token: ${GATEWAY_TOKEN}' \
+curl -X POST https://${GATEWAY_HOST}/scw \
+             -H 'X-Auth-Token: ${TOKEN}' \
              -H 'Content-Type: application/json' \
              -d '{"target":"$1","relative_url":"$2"}'

--- a/functions/serverless-gateway-python/scripts/delete_function_from_gateway.sh
+++ b/functions/serverless-gateway-python/scripts/delete_function_from_gateway.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-curl -X POST https://${GATEWAY_URL}/scw \
-             -H 'X-Auth-Token: ${GATEWAY_TOKEN}' \
+curl -X POST https://${GATEWAY_HOST}/scw \
+             -H 'X-Auth-Token: ${TOKEN}' \
              -H 'Content-Type: application/json' \
              -d '{"target":"$1","relative_url":"$2"}'

--- a/functions/serverless-gateway-python/scripts/list_gateway_endpoints.sh
+++ b/functions/serverless-gateway-python/scripts/list_gateway_endpoints.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-curl https://${GATEWAY_URL}/scw -H 'X-Auth-Token: ${GATEWAY_TOKEN}'
+curl https://${GATEWAY_HOST}/scw -H 'X-Auth-Token: ${TOKEN}'


### PR DESCRIPTION
added ./scripts/
Changed environment variable in scripts to match README and Serverless Gateway Quick Start

## Summary

## Checklist

- [x] I have reviewed this myself.
- [ ] I have attached a README to my example. You can use [this template](../docs/templates/readme-example-template.md) as reference.
- [ ] I have updated the project README to link my example.

## Details
