### PR TITLE
fix(functions): disable s3 upload for offline golang test

### DIFF
--- a/.github/workflows/go-function-offline-testing.yml
+++ b/.github/workflows/go-function-offline-testing.yml
@@ -43,9 +43,4 @@ jobs:
           SQS_SECRET_KEY: ${{ secrets.SQS_SECRET_KEY }}
 
           # for go-upload-file-s3-multipart example
-          S3_ENABLED: true
-          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-          S3_ACCESSKEY: ${{ secrets.SCW_ACCESS_KEY }}
-          S3_SECRET: ${{ secrets.SCW_SECRET_KEY }}
-          S3_BUCKET_NAME: ${{secrets.S3_BUCKET_NAME}}
-          S3_REGION: ${{ secrets.SCW_DEFAULT_REGION }}
+          S3_ENABLED: false


### PR DESCRIPTION
## Summary

Given that the test never checks for the presence of the uploaded file to s3, it's makes more sense to me to disable s3 upload to fix the CI for now.

IMO, the test is mainly here to verify that the function supports multipart upload locally.

## Checklist

- [x] I have reviewed this myself.
- [ ] I have attached a README to my example. You can use [this template](../docs/templates/readme-example-template.md) as reference.
- [ ] I have updated the project README to link my example.

## Details

- See the body of the test: https://github.com/scaleway/serverless-examples/blob/main/functions/go-upload-file-s3-multipart/handler_test.go
