### PR TITLE
chore(triggers): update containers examples for new MnQ API

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Table of Contents:
 | **[NGINX CORS Private](containers/nginx-cors-private-python/README.md)** <br/> An NGINX proxy to allow CORS requests to a private container.                                                | Python Flask | [Terraform]            |
 | **[NGINX hello world](containers/nginx-hello-world/README.md)** <br/> A minimal example running the base NGINX image in a serverless container.                                             | N/A          | [Serverless Framework] |
 | **[Terraform NGINX hello world](containers/terraform-nginx-hello-world/README.md)** <br/> A minimal example running the base NGINX image in a serverless container deployed with Terraform. | N/A          | [Terraform]            |
+| **[Triggers with Terraform](containers/terraform-triggers/README.md)** <br/> Configuring two SQS triggers, used to trigger two containers, one public, one private.                         | N/A          | [Terraform]            |
 
 ### 💜 Projects
 

--- a/containers/terraform-triggers/README.md
+++ b/containers/terraform-triggers/README.md
@@ -43,30 +43,52 @@ terraform init
 terraform apply
 ```
 
-## Tests
+## Running
 
-You can send some messages by using the provided python script in [`tests/`](tests/) folder.
+You can test your triggers by sending messages to the SQS queues configured with Terraform.
+
+Below there is an example showing how to do this using a Python script in the [`tests/`](tests/) folder of this repo.
+
+### Setup
+
+First you need to export your queue credentials and URLs:
 
 ```shell
 export AWS_ACCESS_KEY_ID=$(terraform output -raw sqs_admin_access_key)
 export AWS_SECRET_ACCESS_KEY=$(terraform output -raw sqs_admin_secret_key)
 export PUBLIC_QUEUE_URL=$(terraform output -raw public_queue)
 export PRIVATE_QUEUE_URL=$(terraform output -raw private_queue)
-
-python3 -m venv tests/env
-source tests/env/bin/activate
-python3 -m pip install -r tests/requirements.txt
-python3 tests/send_messages.py
 ```
 
-You can then check logs of your containers in your cockpit (assuming you have activated it in your project):
+You can then set up a Python environment in the `tests` directory:
+
+```
+cd tests
+python3 -m venv venv
+source venv/bin/activate
+pip3 install -r requirements.txt
+```
+
+### Sending messages
+
+You can now run the script to send messages to both queues with:
+
+```
+python3 send_messages.py
+```
+
+### Viewing function logs
+
+In your [Cockpit](https://console.scaleway.com/cockpit), you can access the logs from your queues and functions.
+
+Navigate from your Cockpit to Grafana, and find the `Serverless Containers Logs` dashboard. There you should see the "Hello World!" messages for the functions created by this example.
+
+To get direct deep links to the function logs in Cockpit, you can also run the following from the root of the project:
 
 ```shell
 echo "Go to $(terraform output --raw cockpit_logs_public_container) to see public container logs in cockpit"
 echo "Go to $(terraform output --raw cockpit_logs_private_container) to see private container logs in cockpit"
 ```
-
-You should be able to see the "Hello World!" messages there.
 
 Finally, you can modify `docker/python/server.py` (or `docker/go/server.go`) as you wish and run `terraform apply` to redeploy the new version of the container.
 

--- a/containers/terraform-triggers/README.md
+++ b/containers/terraform-triggers/README.md
@@ -37,7 +37,7 @@ The deployment will do the following:
 
 To run the deployment:
 
-```
+```shell
 terraform init
 
 terraform apply

--- a/containers/terraform-triggers/mnq_sqs.tf
+++ b/containers/terraform-triggers/mnq_sqs.tf
@@ -1,41 +1,27 @@
-resource "scaleway_mnq_namespace" "main" {
-  protocol = "sqs_sns"
-}
-
-# admin credentials used to create the queues, and to send messages (see tests/send_messages.py)
-resource "scaleway_mnq_credential" "main" {
-  namespace_id = scaleway_mnq_namespace.main.id
-
-  sqs_sns_credentials {
-    permissions {
-      can_publish = true
-      can_receive = true
-      can_manage  = true
-    }
+# Admin credentials used to create the queues, and to send messages (see tests/send_messages.py)
+resource "scaleway_mnq_sqs_credentials" "main" {
+  permissions {
+    can_publish = true
+    can_receive = true
+    can_manage  = true
   }
 }
 
 locals {
-  sqs_admin_credentials_access_key = scaleway_mnq_credential.main.sqs_sns_credentials.0.access_key
-  sqs_admin_credentials_secret_key = scaleway_mnq_credential.main.sqs_sns_credentials.0.secret_key
+  sqs_admin_credentials_access_key = scaleway_mnq_sqs_credentials.main.access_key
+  sqs_admin_credentials_secret_key = scaleway_mnq_sqs_credentials.main.secret_key
 }
 
-resource "scaleway_mnq_queue" "public" {
-  namespace_id = scaleway_mnq_namespace.main.id
-  name         = "sqs-queue-public"
+resource "scaleway_mnq_sqs_queue" "public" {
+  name = "sqs-queue-public"
 
-  sqs {
-    access_key = local.sqs_admin_credentials_access_key
-    secret_key = local.sqs_admin_credentials_secret_key
-  }
+  access_key = local.sqs_admin_credentials_access_key
+  secret_key = local.sqs_admin_credentials_secret_key
 }
 
-resource "scaleway_mnq_queue" "private" {
-  namespace_id = scaleway_mnq_namespace.main.id
-  name         = "sqs-queue-private"
+resource "scaleway_mnq_sqs_queue" "private" {
+  name = "sqs-queue-private"
 
-  sqs {
-    access_key = local.sqs_admin_credentials_access_key
-    secret_key = local.sqs_admin_credentials_secret_key
-  }
+  access_key = local.sqs_admin_credentials_access_key
+  secret_key = local.sqs_admin_credentials_secret_key
 }

--- a/containers/terraform-triggers/outputs.tf
+++ b/containers/terraform-triggers/outputs.tf
@@ -3,7 +3,7 @@ output "public_endpoint" {
 }
 
 output "public_queue" {
-  value = scaleway_mnq_queue.public.sqs[0].url
+  value = scaleway_mnq_sqs_queue.public.url
 }
 
 output "private_endpoint" {
@@ -11,15 +11,16 @@ output "private_endpoint" {
 }
 
 output "private_queue" {
-  value = scaleway_mnq_queue.private.sqs[0].url
+  value = scaleway_mnq_sqs_queue.private.url
 }
 
 output "sqs_admin_access_key" {
-  value = scaleway_mnq_credential.main.sqs_sns_credentials[0].access_key
+  value = scaleway_mnq_sqs_credentials.main.access_key
+  sensitive = true
 }
 
 output "sqs_admin_secret_key" {
-  value     = scaleway_mnq_credential.main.sqs_sns_credentials[0].secret_key
+  value     = scaleway_mnq_sqs_credentials.main.secret_key
   sensitive = true
 }
 

--- a/containers/terraform-triggers/triggers.tf
+++ b/containers/terraform-triggers/triggers.tf
@@ -2,8 +2,7 @@ resource "scaleway_container_trigger" "public" {
   container_id = scaleway_container.public.id
   name         = "public-trigger"
   sqs {
-    namespace_id = scaleway_mnq_namespace.main.id
-    queue        = scaleway_mnq_queue.public.name
+    queue = scaleway_mnq_sqs_queue.public.name
   }
 }
 
@@ -19,8 +18,7 @@ resource "scaleway_container_trigger" "private" {
   container_id = scaleway_container.private.id
   name         = "private-trigger"
   sqs {
-    namespace_id = scaleway_mnq_namespace.main.id
-    queue        = scaleway_mnq_queue.private.name
+    queue = scaleway_mnq_sqs_queue.private.name
   }
 
   depends_on = [time_sleep.wait_10_seconds_after_public_trigger_creation]

--- a/containers/terraform-triggers/versions.tf
+++ b/containers/terraform-triggers/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     scaleway = {
       source  = "scaleway/scaleway"
-      version = "2.30.0"
+      version = ">=2.31.0"
     }
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
## Summary

Use new MnQ Terraform resources and new Triggers API.

## Checklist

- [x] I have reviewed this myself.
- [ ] I have attached a README to my example. You can use [this template](../docs/templates/readme-example-template.md) as reference.
- [ ] I have updated the project README to link my example.