### PR TITLE
Remove unnecessary wait between two triggers creation

### DIFF
--- a/containers/terraform-triggers/triggers.tf
+++ b/containers/terraform-triggers/triggers.tf
@@ -6,20 +6,10 @@ resource "scaleway_container_trigger" "public" {
   }
 }
 
-# There is a small bug today when multiple triggers are created at the same time
-# We'll wait 10 seconds before creating other triggers
-resource "time_sleep" "wait_10_seconds_after_public_trigger_creation" {
-  depends_on = [scaleway_container_trigger.public]
-
-  create_duration = "10s"
-}
-
 resource "scaleway_container_trigger" "private" {
   container_id = scaleway_container.private.id
   name         = "private-trigger"
   sqs {
     queue = scaleway_mnq_sqs_queue.private.name
   }
-
-  depends_on = [time_sleep.wait_10_seconds_after_public_trigger_creation]
 }


### PR DESCRIPTION
## Summary

Remove unnecessary wait between two triggers creation in Terraform container example.

## Checklist

- [X] I have reviewed this myself.
- [ ] I have attached a README to my example. You can use [this template](../docs/templates/readme-example-template.md) as reference.
- [ ] I have updated the project README to link my example.

## Details

The bug happening when multiple triggers were created at the same time is now fixed, so we don't need to wait anymore between multiple triggers creation in the same project.

I've tested this example, it runs fine now :+1: 