### PR TITLE
fix(project): change URL page for large-messages example

### DIFF
--- a/projects/large-messages/README.md
+++ b/projects/large-messages/README.md
@@ -1,6 +1,6 @@
 # Serverless large messages architecture
 
-This repository contains the source code for the this tutorial: [Create a serverless architecture that manage large messages, with Scaleway Messaging and Queuing NATS, Serverless Functions and Object Storage.](https://github.com/scaleway/docs-content/blob/int-add-mnq-tuto/tutorials/large-messages/index.mdx)
+This repository contains the source code for this tutorial: [Create a serverless architecture that manage large messages, with Scaleway Messaging and Queuing NATS, Serverless Functions and Object Storage.](https://www.scaleway.com/en/docs/tutorials/large-messages/)
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
Change the URL for large-messages example to point directly to the official Scaleway documentation
## Checklist

- [x] I have reviewed this myself.
- [x] I have attached a README to my example. You can use [this template](../docs/templates/readme-example-template.md) as reference.
- [x] I have updated the project README to link my example.

## Details
