### PR TITLE
feat(functions): add tem example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Table of Contents:
 | **[Python MultiPart Upload to S3](functions/python-upload-file-s3-multipart/README.md)** <br/> A function to upload file from form-data to S3.                                        | python311 | [Python API Framework] |
 | **[Python SQS Trigger Hello World](functions/python-sqs-trigger-hello-world/README.md)** <br/> Trigger a function by sending a message to a SQS queue.                                | python311 | [Terraform]            |
 | **[Python SQS Trigger Async Worker](functions/python-sqs-trigger-async-worker/README.md)** <br/> Use SQS queues and function triggers to scheule an async task from another function. | python311 | [Terraform]            |
-| **[Python TEM SMTP Server](functions/python-tem-smtp-server/README.md)** <br/> Send TEM from a serverless function.                   | python311 | [Terraform]            |
+| **[Python TEM SMTP Server](functions/python-tem-smtp-server/README.md)** <br/> Send Transactional Emails from a serverless function.                                                  | python311 | [Terraform]            |
 | **[Redis TLS](functions/redis-tls/README.md)** <br/> How to connect a function to a Scaleway Redis cluster with TLS enabled.                                                          | python310 | [Terraform]            |
 | **[Rust MNIST](functions/rust-mnist/README.md)** <br/> A Rust function to recognize hand-written digits with a simple neural network.                                                 | rust165   | [Serverless Framework] |
 | **[PostgreSQL Python](functions/postgre-sql-python/README.md)** <br/> A Python function to perform a query on a PostgreSQL managed database.                                          | python310 | [Serverless Framework] |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Table of Contents:
 <!-- markdownlint-disable MD033 -->
 
 | Example                                                                                                                                                                               | Runtime   | Deployment             |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---------------------- |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --------- | ---------------------- |
 | **[Badge PHP](functions/badge-php/README.md)** <br/> A PHP function to generate repository badges.                                                                                    | php82     | [Serverless Framework] |
 | **[CORS Go](functions/cors-go/README.md)** <br/> A Go function which allows CORS requests.                                                                                            | go119     | [Serverless Framework] |
 | **[CORS Node](functions/cors-node/README.md)** <br/> A Node function which allows CORS requests.                                                                                      | node18    | [Serverless Framework] |
@@ -49,6 +49,7 @@ Table of Contents:
 | **[Python MultiPart Upload to S3](functions/python-upload-file-s3-multipart/README.md)** <br/> A function to upload file from form-data to S3.                                        | python311 | [Python API Framework] |
 | **[Python SQS Trigger Hello World](functions/python-sqs-trigger-hello-world/README.md)** <br/> Trigger a function by sending a message to a SQS queue.                                | python311 | [Terraform]            |
 | **[Python SQS Trigger Async Worker](functions/python-sqs-trigger-async-worker/README.md)** <br/> Use SQS queues and function triggers to scheule an async task from another function. | python311 | [Terraform]            |
+| **[Python TEM SMTP Server](functions/python-tem-smtp-server/README.md)** <br/> Send TEM from a serverless function.                   | python311 | [Terraform]            |
 | **[Redis TLS](functions/redis-tls/README.md)** <br/> How to connect a function to a Scaleway Redis cluster with TLS enabled.                                                          | python310 | [Terraform]            |
 | **[Rust MNIST](functions/rust-mnist/README.md)** <br/> A Rust function to recognize hand-written digits with a simple neural network.                                                 | rust165   | [Serverless Framework] |
 | **[PostgreSQL Python](functions/postgre-sql-python/README.md)** <br/> A Python function to perform a query on a PostgreSQL managed database.                                          | python310 | [Serverless Framework] |

--- a/functions/python-tem-smtp-server/README.md
+++ b/functions/python-tem-smtp-server/README.md
@@ -1,0 +1,59 @@
+# Send TEM from a serverless function
+
+This example demonstrates how to send TEM with an SMTP server from Python functions.
+
+It assumes that you are familiar with how Serverless Functions and Scaleway Transactional Email work. 
+If needed, you can check the Scaleway official documentation for serverless functions [here](https://www.scaleway.com/en/docs/serverless/functions/quickstart/) 
+and for TEM [here](https://www.scaleway.com/en/docs/managed-services/transactional-email/quickstart/).
+
+## Requirements
+
+* You have configured your domain with Transactional Email
+* You have generated an API key with the permission `TransactionalEmailFullAccess`
+* You have [Python](https://www.python.org/) installed on your machine
+* You have [Terraform](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs) installed on your machine
+
+## Testing with serverless offline for Python
+
+In order to test your function locally before the deployment, you can install our offline testing library with:
+
+```bash
+pip install scaleway_functions_python==0.2.0
+```
+
+Export your environment variables and then launch your function locally:
+```bash
+export TEM_PROJECT_ID=<the Project ID of the Project in which the TEM domain was created>
+export SECRET_KEY=<the secret key of the API key of the project used to manage your TEM domain>
+
+python handler.py
+```
+
+Test your local function using `curl`:
+
+```bash
+curl http://localhost:8080
+```
+
+This should email the recipient defined in `handler.py`.
+
+## Deploy
+
+Use the Terraform configuration to deploy the function.
+
+```shell
+terraform init
+terraform apply -var "swc_project_id=$TEM_PROJECT_ID" -var "scw_secret_key=$SECRET_KEY"
+```
+
+## Call the function
+
+When the deployment is complete, you can check the deployment succeeded either by:
+
+i) curl the container's endpoint with:
+```sh
+curl $(terraform output -raw endpoint)
+```
+ii) hit it from a browser.
+
+Doing so will send an e-mail to the recipient defined in the file `handler.py`.

--- a/functions/python-tem-smtp-server/README.md
+++ b/functions/python-tem-smtp-server/README.md
@@ -43,7 +43,7 @@ Use the Terraform configuration to deploy the function.
 
 ```shell
 terraform init
-terraform apply -var "swc_project_id=$TEM_PROJECT_ID" -var "scw_secret_key=$SECRET_KEY"
+terraform apply -var "scw_project_id=$TEM_PROJECT_ID" -var "scw_secret_key=$SECRET_KEY"
 ```
 
 ## Call the function

--- a/functions/python-tem-smtp-server/README.md
+++ b/functions/python-tem-smtp-server/README.md
@@ -1,4 +1,4 @@
-# Send TEM from a serverless function
+# Send Transactional Emails from a Serverless Function
 
 This example demonstrates how to send TEM with an SMTP server from Python functions.
 
@@ -8,10 +8,17 @@ and for TEM [here](https://www.scaleway.com/en/docs/managed-services/transaction
 
 ## Requirements
 
-* You have configured your domain with Transactional Email
 * You have generated an API key with the permission `TransactionalEmailFullAccess`
 * You have [Python](https://www.python.org/) installed on your machine
 * You have [Terraform](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs) installed on your machine
+
+## Setup
+
+You have to configure your domain with Transactional Email (tutorial available [here](https://www.scaleway.com/en/docs/managed-services/transactional-email/quickstart/))
+
+Then, edit the file `handler.py` to set the sender and the recipient of the email. 
+
+Also, depending on your SMTP server, you might also need to change the value of the variables `host` and `port`.
 
 ## Testing with serverless offline for Python
 

--- a/functions/python-tem-smtp-server/handler.py
+++ b/functions/python-tem-smtp-server/handler.py
@@ -1,0 +1,33 @@
+import os
+import logging
+import smtplib
+from email.mime.text import MIMEText
+
+def handle(event, context):
+
+	# SMTP configuration, see https://www.scaleway.com/en/docs/managed-services/transactional-email/reference-content/smtp-configuration/ for more info
+
+	host = "smtp.tem.scw.cloud" # The domain name or IP address of the SMTP server. If you are using Scaleway TEM, the domain to use is smtp.tem.scw.cloud
+	port = 465
+
+	login = os.environ.get('TEM_PROJECT_ID') # Your Scaleway SMTP username is the Project ID of the Project in which the TEM domain was created
+	password = os.environ.get('SECRET_KEY') # Your password is the secret key of the API key of the project used to manage your TEM domain
+
+	sender_email = "jdoe@fake-domain.com" # the email address that will appear as the sender
+	receiver_email = "jdoe@fake-email.com" # the email address to send the email to
+
+	message = MIMEText("You've successfully sent an email from Serverless Functions!", "plain")
+	message["Subject"] = "Congratulations"
+	message["From"] = sender_email
+	message["To"] = receiver_email
+
+	try:
+		with smtplib.SMTP_SSL(host, port) as server:
+			server.login(login, password)
+			server.sendmail(sender_email, receiver_email, message.as_string())
+	except Exception as e:
+		logging.error("Failed to send email: %s", e)
+
+if __name__ == "__main__":
+	from scaleway_functions_python import local
+	local.serve_handler(handle)

--- a/functions/python-tem-smtp-server/handler.py
+++ b/functions/python-tem-smtp-server/handler.py
@@ -3,31 +3,40 @@ import logging
 import smtplib
 from email.mime.text import MIMEText
 
+
 def handle(event, context):
 
-	# SMTP configuration, see https://www.scaleway.com/en/docs/managed-services/transactional-email/reference-content/smtp-configuration/ for more info
+    # SMTP configuration, see https://www.scaleway.com/en/docs/managed-services/transactional-email/reference-content/smtp-configuration/ for more info
 
-	host = "smtp.tem.scw.cloud" # The domain name or IP address of the SMTP server. If you are using Scaleway TEM, the domain to use is smtp.tem.scw.cloud
-	port = 465
+    host = "smtp.tem.scw.cloud"  # The domain name or IP address of the SMTP server. If you are using Scaleway TEM, the domain to use is smtp.tem.scw.cloud
+    port = 465
 
-	login = os.environ.get('TEM_PROJECT_ID') # Your Scaleway SMTP username is the Project ID of the Project in which the TEM domain was created
-	password = os.environ.get('SECRET_KEY') # Your password is the secret key of the API key of the project used to manage your TEM domain
+    # Your Scaleway SMTP username is the Project ID of the Project in which the TEM domain was created
+    login = os.environ.get("TEM_PROJECT_ID")
+    # Your password is the secret key of the API key of the project used to manage your TEM domain
+    password = os.environ.get("SECRET_KEY")
 
-	sender_email = "jdoe@fake-domain.com" # the email address that will appear as the sender
-	receiver_email = "jdoe@fake-email.com" # the email address to send the email to
+    # the email address that will appear as the sender
+    sender_email = "jdoe@fake-domain.com"
+    # the email address to send the email to
+    receiver_email = "jdoe@fake-email.com"
 
-	message = MIMEText("You've successfully sent an email from Serverless Functions!", "plain")
-	message["Subject"] = "Congratulations"
-	message["From"] = sender_email
-	message["To"] = receiver_email
+    message = MIMEText(
+        "You've successfully sent an email from Serverless Functions!", "plain"
+    )
+    message["Subject"] = "Congratulations"
+    message["From"] = sender_email
+    message["To"] = receiver_email
 
-	try:
-		with smtplib.SMTP_SSL(host, port) as server:
-			server.login(login, password)
-			server.sendmail(sender_email, receiver_email, message.as_string())
-	except Exception as e:
-		logging.error("Failed to send email: %s", e)
+    try:
+        with smtplib.SMTP_SSL(host, port) as server:
+            server.login(login, password)
+            server.sendmail(sender_email, receiver_email, message.as_string())
+    except Exception as e:
+        logging.error("Failed to send email: %s", e)
+
 
 if __name__ == "__main__":
-	from scaleway_functions_python import local
-	local.serve_handler(handle)
+    from scaleway_functions_python import local
+
+    local.serve_handler(handle)

--- a/functions/python-tem-smtp-server/main.tf
+++ b/functions/python-tem-smtp-server/main.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = ">= 2.40"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.4"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+variable "swc_project_id" {
+  type = string
+}
+
+variable "scw_secret_key" {
+  type = string
+  sensitive = true
+}
+
+data "archive_file" "function" {
+  type        = "zip"
+  source_file = "${path.module}/handler.py"
+  output_path = "${path.module}/function.zip"
+}
+
+resource "scaleway_function_namespace" "main" {
+  name        = "serverless-with-tem-example"
+  description = "Serverless with TEM example"
+}
+
+resource "scaleway_function" "main" {
+  namespace_id = scaleway_function_namespace.main.id
+  name         = "python-tem-smtp-server"
+  runtime      = "python311"
+  handler      = "handler.handle"
+  privacy      = "public"
+  zip_file     = data.archive_file.function.output_path
+  zip_hash     = data.archive_file.function.output_sha256
+  deploy       = true
+
+  secret_environment_variables = {
+    TEM_PROJECT_ID = var.swc_project_id
+    SECRET_KEY = var.scw_secret_key
+  }
+}
+
+output "endpoint" {
+  value = scaleway_function.main.domain_name
+}

--- a/functions/python-tem-smtp-server/main.tf
+++ b/functions/python-tem-smtp-server/main.tf
@@ -12,7 +12,7 @@ terraform {
   required_version = ">= 1.0"
 }
 
-variable "swc_project_id" {
+variable "scw_project_id" {
   type = string
 }
 
@@ -43,7 +43,7 @@ resource "scaleway_function" "main" {
   deploy       = true
 
   secret_environment_variables = {
-    TEM_PROJECT_ID = var.swc_project_id
+    TEM_PROJECT_ID = var.scw_project_id
     SECRET_KEY = var.scw_secret_key
   }
 }


### PR DESCRIPTION
## Summary

Add an example to send TEM from a serverless function.

## Checklist

- [X] I have reviewed this myself.
- [X] I have attached a README to my example. You can use [this template](../docs/templates/readme-example-template.md) as reference.
- [X] I have updated the project README to link my example.

## Details

The function was tested locally with scaleway_functions_python library. It was also deployed, and an email was sent successfully.
