### PR TITLE
fix(functions): cors-rust example

### DIFF
--- a/functions/cors-rust/src/lib.rs
+++ b/functions/cors-rust/src/lib.rs
@@ -2,7 +2,7 @@ use axum::{body::Body, extract::Request, response::Response};
 use http::StatusCode;
 
 // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#the_http_response_headers
-pub fn with_permissive_cors(r: response::Builder) -> response::Builder {
+pub fn with_permissive_cors(r: http::response::Builder) -> http::response::Builder {
     r.header("Access-Control-Allow-Headers", "*")
         .header("Access-Control-Allow-Methods", "*")
         .header("Access-Control-Allow-Origin", "*")


### PR DESCRIPTION
## Summary

## Checklist

- [x] I have reviewed this myself.
- [ ] I have attached a README to my example. You can use [this template](../docs/templates/readme-example-template.md) as reference.
- [ ] I have updated the project README to link my example.

## Details

The current Rust CORS example does compile

```
error[E0433]: failed to resolve: use of undeclared crate or module `response`
 --> function/src/lib.rs:5:32
  |
5 | pub fn with_permissive_cors(r: response::Builder) -> response::Builder {
  |                                ^^^^^^^^ use of undeclared crate or module `response`
  |
help: a type alias with a similar name exists
  |
5 | pub fn with_permissive_cors(r: Response::Builder) -> response::Builder {
  |                                ~~~~~~~~
help: consider importing this module
  |
1 + use http::response;
  |
error[E0433]: failed to resolve: use of undeclared crate or module `response`
 --> function/src/lib.rs:5:54
  |
5 | pub fn with_permissive_cors(r: response::Builder) -> response::Builder {
  |                                                      ^^^^^^^^ use of undeclared crate or module `response`
  |
help: a type alias with a similar name exists
  |
5 | pub fn with_permissive_cors(r: response::Builder) -> Response::Builder {
  |                                                      ~~~~~~~~
help: consider importing this module
  |
1 + use http::response;
  |
For more information about this error, try `rustc --explain E0433`.
error: could not compile `cors-rust` (lib) due to 2 previous errors
```

This PR explicitly reference the http module in the method parameters.