### PR TITLE
Update instance type + image, python version

### DIFF
--- a/functions/terraform-python-example/main.tf
+++ b/functions/terraform-python-example/main.tf
@@ -81,7 +81,7 @@ resource "scaleway_function_namespace" "main" {
 resource "scaleway_function" "main" {
   namespace_id = scaleway_function_namespace.main.id
   name         = "instancewake"
-  runtime      = "python312"
+  runtime      = "python313"
   handler      = "handler.handle"
   privacy      = "public"
   zip_file     = data.archive_file.source_zip.output_path

--- a/functions/terraform-python-example/main.tf
+++ b/functions/terraform-python-example/main.tf
@@ -6,8 +6,8 @@ resource "scaleway_instance_ip" "public_ip-prod" {
 resource "scaleway_instance_server" "scw-instance-prod" {
   name       = "prod"
   project_id = var.project_id
-  type       = "GP1-S"
-  image      = "ubuntu_focal"
+  type       = "GP1-XS"
+  image      = "ubuntu_noble"
 
   tags = ["terraform instance", "scw-instance", "production"]
 
@@ -29,8 +29,8 @@ resource "scaleway_instance_ip" "public_ip-dev" {
 resource "scaleway_instance_server" "scw-instance-dev" {
   name       = "dev"
   project_id = var.project_id
-  type       = "DEV1-L"
-  image      = "ubuntu_focal"
+  type       = "DEV1-S"
+  image      = "ubuntu_noble"
 
   tags = ["terraform instance", "scw-instance", "dev"]
 
@@ -81,7 +81,7 @@ resource "scaleway_function_namespace" "main" {
 resource "scaleway_function" "main" {
   namespace_id = scaleway_function_namespace.main.id
   name         = "instancewake"
-  runtime      = "python310"
+  runtime      = "python312"
   handler      = "handler.handle"
   privacy      = "public"
   zip_file     = data.archive_file.source_zip.output_path

--- a/functions/terraform-python-example/provider.tf
+++ b/functions/terraform-python-example/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     scaleway = {
       source  = "scaleway/scaleway"
-      version = "2.9.1"
+      version = "2.52.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
## Summary

Updated some small things because they were breaking the example. Provider, Ubuntu images, instance types.

## Checklist

- [x] I have reviewed this myself.
- [ ] I have attached a README to my example. You can use [this template](../docs/templates/readme-example-template.md) as reference.
- [ ] I have updated the project README to link my example.

## Details
- Provider was outdated.
- Ubuntu images were of an older version.
- Not all instance types were supported without quotas.

Also bumped the Python version to prevent it going out of support before this repo is updated again.

