### PR TITLE
chore(containers): clean-up gRPC example

### DIFF
--- a/containers/grpc-http2-go/Dockerfile
+++ b/containers/grpc-http2-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bookworm as build
+FROM golang:1.26-bookworm AS build
 
 # Set working directory
 WORKDIR /app

--- a/containers/grpc-http2-go/README.md
+++ b/containers/grpc-http2-go/README.md
@@ -18,74 +18,74 @@ Here are the different steps we are going to proceed:
 ### Requirements
 
 To complete the actions presented below, you must have:
+
 - installed and configured the [Scaleway CLI](https://www.scaleway.com/en/docs/developer-tools/scaleway-cli/quickstart/)
 - installed [Docker](https://docs.docker.com/engine/install/) to build the image
 - installed the common [gRPC stack](https://grpc.io/blog/installation/)) to test locally (optional)
 
 ### Building the image
 
-1. Run the following command in a terminal to create Container Registry namespace to store the image:
+- Run the following command in a terminal to create Container Registry namespace to store the image:
 
-    ```bash
-    scw registry namespace create name=hello-grpc
-    ```
-
-  The registry namespace information displays.
+```bash
+scw registry namespace create name=hello-grpc
+```
   
-1. Copy the namespace endpoint (in this case, `rg.fr-par.scw.cloud/hello-grpc`). 
+- Copy the namespace endpoint (in this case, `rg.fr-par.scw.cloud/hello-grpc`).
 
-1. Log into the Container Registry namespace you created using Docker: 
+- Login to the Scaleway Container Registry using the CLI:
 
-    ```bash
-    docker login rg.fr-par.scw.cloud/hello-grpc -u nologin --password-stdin <<< "$SCW_SECRET_KEY"
-    ```
+```bash
+scw registry login
+```
 
-  At this point, you have correctly set up Docker to be able to push your image online.
+At this point, you have correctly set up Docker to be able to push your image online.
 
-1. In a terminal, access this directory (containing the Dockerfile), and run the following command to build the image:
+In a terminal, access this directory (containing the Dockerfile), and run the following command to build the image:
 
-    ```bash
-    docker build -t grpc:latest .
-    ```
+```bash
+docker build -t grpc:latest .
+```
 
-1. Tag and push the image to the registry namespace:
+- Tag and push the image to the registry namespace:
 
-    ```bash
-    docker tag grpc:latest rg.fr-par.scw.cloud/hello-grpc/grpc:latest
-    docker push rg.fr-par.scw.cloud/hello-grpc/grpc:latest
-    ```
+```bash
+docker tag grpc:latest rg.fr-par.scw.cloud/hello-grpc/grpc:latest
+docker push rg.fr-par.scw.cloud/hello-grpc/grpc:latest
+```
 
 ### Deploying the image
 
 In a terminal, run the following command to create a Serverless Containers namespace:
 
-    ```bash
-    scw container namespace create name=grpc-test
-    ```
-    The namespace information displays.
+```bash
+scw container namespace create name=grpc-test
+```
 
-1. Copy the namespace ID.
+The namespace information displays.
 
-1. Run the following command to create and deploy the container (make sure to use the `h2c` protocol to connect via HTTP2):
+- Copy the namespace ID.
+- Run the following command to create and deploy the container (make sure to use the `h2c` protocol to connect via HTTP2):
 
-    ```bash
-    scw container container create namespace-id=<PREVIOUS_NAMESPACE_ID> protocol=h2c name=grpc-test registry-image=rg.fr-par.scw.cloud/hello-grpc/grpc:latest
-    ```
-    The container information displays.
+```bash
+scw container container create namespace-id=<PREVIOUS_NAMESPACE_ID> protocol=h2c name=grpc-test registry-image=rg.fr-par.scw.cloud/hello-grpc/grpc:latest
+```
 
-1. Copy the DomainName (endpoint) to test your container.
+- Copy the DomainName (endpoint) to test your container.
 
 ### Testing
 
 Make sure your container is in a `ready` status before testing it.
 
-1. In the `client/client.go` file, replace the constant `containerEndpoint` with the `DomainName` copied previously. 
+- In the `client/client.go` file, replace the constant `containerEndpoint` with the `DomainName` copied previously.
 
-1. Make sure to keep the `:80` port at the end even if you container port is set to 8080, as these are two different settings.
+- Make sure to keep the `:443` port at the end even if you container port is set to 8080, as these are two different settings.
 
-1. Run the command below to check if your container responds:
+- Run the command below to check if your container responds:
 
-    `go run client/client.go' 
+```bash
+go run client/client.go
+```
 
 ## Additional content
 

--- a/containers/grpc-http2-go/client/client.go
+++ b/containers/grpc-http2-go/client/client.go
@@ -2,20 +2,24 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"log"
 	"time"
 
 	pb "github.com/scaleway/serverless-examples/containers/grpc-http2-go"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
-const containerEndpoint = "YOUR_CONTAINER_ENDPOINT:80"
+const containerEndpoint = "YOUR_CONTAINER_ENDPOINT:443"
 
 func main() {
 	flag.Parse()
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(containerEndpoint, grpc.WithInsecure())
+	conn, err := grpc.Dial(containerEndpoint, grpc.WithTransportCredentials(
+		credentials.NewTLS(&tls.Config{}),
+	))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Avoid using unencrypted connection
- Run markdown linter on README.md
- Bump Go version

## Checklist

- [ ] I have reviewed this myself.
- [ ] I have attached a README to my example. You can use [this template](../docs/templates/readme-example-template.md) as reference.
- [ ] I have updated the project README to link my example.

## Details
