### PR TITLE
feat: add fastapi streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Table of Contents:
 | **[Deploy Memos app](containers/memos-terraform/)** <br/> A journaling application with its database deployed with Terraform                                                                | Terraform          | [Terraform]            |
 | **[Metabase on VPC](containers/vpc-metabase/README.md)** <br/> A Metabase instance running in a private network with a PostgreSQL database.                                                 | N/A                | [Terraform]            |
 | **[MongoDB® on VPC](containers/vpc-mongodb/README.md)** <br/> A MongoDB® instance running in a private network with a sample application connecting to it.                                  | TypeScript on Deno | [Terraform]            |
+| **[FastAPI Streaming (SSE)](containers/python-fastapi-stream/README.md)** <br/> A FastAPI container streaming Server-Sent Events to debug proxy buffering and connection timeouts.          | Python             | [CLI]                  |
 
 ### ⚙️ Jobs
 

--- a/containers/python-fastapi-stream/Dockerfile
+++ b/containers/python-fastapi-stream/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.14-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app/ ./app/
+
+EXPOSE 8080
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080", "--workers", "1", "--no-access-log"]

--- a/containers/python-fastapi-stream/README.md
+++ b/containers/python-fastapi-stream/README.md
@@ -1,0 +1,70 @@
+# FastAPI Streaming Example
+
+A minimal FastAPI container with Server-Sent Events (SSE) streaming responses, designed for debugging network issues on Scaleway Serverless Containers.
+
+## Endpoints
+
+| Method    | Path                       | Description                              |
+| --------- | -------------------------- | ---------------------------------------- |
+| `GET`     | `/`                        | Browser test page (HTML)                 |
+| `GET`     | `/health`                  | Health check                             |
+| `POST`    | `/public/completions`      | Stream SSE events (configurable)         |
+| `POST`    | `/public/completions/long` | Long-duration stream for timeout testing |
+| `OPTIONS` | `/public/completions`      | CORS preflight                           |
+
+### `/public/completions` query params
+
+| Param    | Default | Description                  |
+| -------- | ------- | ---------------------------- |
+| `chunks` | `10`    | Number of SSE events to emit |
+| `delay`  | `1.0`   | Seconds between each event   |
+
+### `/public/completions/long` query params
+
+| Param      | Default | Description             |
+| ---------- | ------- | ----------------------- |
+| `duration` | `300`   | Total seconds to stream |
+| `interval` | `5`     | Seconds between events  |
+
+## Local development (Nix)
+
+```bash
+nix-shell
+pip install -r requirements.txt
+uvicorn app.main:app --host 0.0.0.0 --port 8080
+```
+
+## Build & deploy (Scaleway)
+
+```bash
+scw container deploy
+```
+
+## Testing
+
+### Browser
+
+Open `http://localhost:8080/` (or your deployed container URL) in a browser. The test page lets you:
+
+- Set the number of chunks and delay between events
+- Start, stop, and clear streams
+- See SSE events and network errors in real time
+
+### CLI
+
+```bash
+# Quick test
+curl -N -X POST http://localhost:8080/public/completions?chunks=5&delay=1
+
+# Long stream (test timeouts)
+curl -N -X POST http://localhost:8080/public/completions/long?duration=600&interval=5
+```
+
+## Streaming headers
+
+The response includes:
+
+- `Content-Type: text/event-stream`
+- `Cache-Control: no-cache`
+- `Connection: keep-alive`
+- `X-Accel-Buffering: no` (disables nginx proxy buffering)

--- a/containers/python-fastapi-stream/README.md
+++ b/containers/python-fastapi-stream/README.md
@@ -26,10 +26,9 @@ A minimal FastAPI container with Server-Sent Events (SSE) streaming responses, d
 | `duration` | `300`   | Total seconds to stream |
 | `interval` | `5`     | Seconds between events  |
 
-## Local development (Nix)
+## Local development
 
 ```bash
-nix-shell
 pip install -r requirements.txt
 uvicorn app.main:app --host 0.0.0.0 --port 8080
 ```

--- a/containers/python-fastapi-stream/app/main.py
+++ b/containers/python-fastapi-stream/app/main.py
@@ -1,0 +1,156 @@
+"""Minimal FastAPI streaming example for debugging purposes."""
+
+import asyncio
+import json
+import time
+import logging
+import os
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="FastAPI Streaming Example")
+
+# Mount static files
+_static_dir = os.path.join(os.path.dirname(__file__), "static")
+app.mount("/static", StaticFiles(directory=_static_dir), name="static")
+
+# Allow CORS for browser-based clients
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+)
+
+# --- SSE helpers -----------------------------------------------------------
+
+def sse_event(data: dict) -> bytes:
+    """Format a dict as a Server-Sent Event."""
+    return f"data: {json.dumps(data)}\n\n".encode("utf-8")
+
+
+# --- Streaming generator ----------------------------------------------------
+
+async def event_stream(chunks: int = 10, delay: float = 1.0):
+    """Yield ``chunks`` SSE events with ``delay`` seconds between each."""
+    for i in range(chunks):
+        payload = {
+            "id": i,
+            "content": f"Chunk {i} of {chunks}",
+            "timestamp": time.time(),
+        }
+        logger.info("Sending chunk %d/%d", i + 1, chunks)
+        yield sse_event(payload)
+        await asyncio.sleep(delay)
+
+    # Final event
+    yield sse_event({"done": True, "total_chunks": chunks})
+
+
+# --- Routes -----------------------------------------------------------------
+
+@app.get("/")
+async def root():
+    """Serve the test HTML page."""
+    from fastapi.responses import FileResponse
+    return FileResponse(os.path.join(_static_dir, "index.html"))
+
+
+@app.get("/health")
+async def health():
+    return {"status": "healthy"}
+
+
+@app.options("/public/completions")
+async def completions_options():
+    """Handle CORS preflight for the streaming endpoint."""
+    return JSONResponse(content={}, headers={
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "*",
+    })
+
+
+@app.post("/public/completions")
+async def completions(request: Request):
+    """Stream a configurable number of SSE events.
+
+    Query params:
+        chunks: number of SSE events to emit (default 10)
+        delay:  seconds between each event (default 1.0)
+    """
+    params = request.query_params
+    chunks = int(params.get("chunks", 10))
+    delay = float(params.get("delay", 1.0))
+
+    logger.info(
+        "Starting stream: chunks=%d delay=%.2f client=%s",
+        chunks, delay, request.client.host if request.client else "unknown",
+    )
+
+    return StreamingResponse(
+        event_stream(chunks=chunks, delay=delay),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",  # disable nginx buffering
+        },
+    )
+
+
+# --- Long stream for stress testing ----------------------------------------
+
+@app.post("/public/completions/long")
+async def completions_long(request: Request):
+    """Stream events for a long duration to test timeouts.
+
+    Query params:
+        duration: total seconds to stream (default 300)
+        interval: seconds between events (default 5)
+    """
+    params = request.query_params
+    duration = float(params.get("duration", 300))
+    interval = float(params.get("interval", 5))
+
+    async def long_stream():
+        start = time.time()
+        i = 0
+        while time.time() - start < duration:
+            i += 1
+            elapsed = time.time() - start
+            yield sse_event({
+                "id": i,
+                "elapsed": round(elapsed, 2),
+                "remaining": round(max(0, duration - elapsed), 2),
+            })
+            await asyncio.sleep(interval)
+
+        yield sse_event({"done": True, "total_events": i})
+
+    logger.info(
+        "Starting long stream: duration=%.0f interval=%.2f client=%s",
+        duration, interval, request.client.host if request.client else "unknown",
+    )
+
+    return StreamingResponse(
+        long_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/containers/python-fastapi-stream/app/static/index.html
+++ b/containers/python-fastapi-stream/app/static/index.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FastAPI Streaming Test</title>
+    <style>
+        :root {
+            font-family: system-ui, -apple-system, sans-serif;
+            background: #1a1a2e;
+            color: #e0e0e0;
+        }
+        body {
+            max-width: 800px;
+            margin: 2rem auto;
+            padding: 0 1rem;
+        }
+        h1 { color: #7ec8e3; }
+        .controls {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            align-items: flex-end;
+            margin-bottom: 1.5rem;
+        }
+        label {
+            display: flex;
+            flex-direction: column;
+            font-size: 0.85rem;
+            gap: 0.25rem;
+        }
+        input, button {
+            padding: 0.5rem;
+            border: 1px solid #444;
+            border-radius: 6px;
+            background: #16213e;
+            color: #e0e0e0;
+            font-size: 0.95rem;
+        }
+        input { width: 100px; }
+        button {
+            cursor: pointer;
+            background: #0f3460;
+            color: #7ec8e3;
+            font-weight: bold;
+            border: none;
+            padding: 0.55rem 1.2rem;
+        }
+        button:hover { background: #1a4a7a; }
+        button:disabled { opacity: 0.5; cursor: not-allowed; }
+        #stop { background: #5a1a1a; color: #ff9999; }
+        #stop:hover { background: #7a2a2a; }
+        #status {
+            margin-bottom: 1rem;
+            font-size: 0.9rem;
+            color: #aaa;
+        }
+        #events {
+            background: #0f0f23;
+            border: 1px solid #333;
+            border-radius: 8px;
+            padding: 1rem;
+            height: 400px;
+            overflow-y: auto;
+            font-family: "SF Mono", "Fira Code", monospace;
+            font-size: 0.85rem;
+            line-height: 1.5;
+        }
+        .event {
+            margin-bottom: 0.3rem;
+            padding: 0.3rem 0.5rem;
+            border-radius: 4px;
+            background: #1a1a3e;
+        }
+        .event.done { color: #7ec8e3; font-weight: bold; }
+        .event.error { color: #ff6b6b; }
+        .meta { color: #888; font-size: 0.8rem; }
+    </style>
+</head>
+<body>
+    <h1>FastAPI Streaming Test</h1>
+
+    <div class="controls">
+        <label>
+            Chunks
+            <input type="number" id="chunks" value="10" min="1" max="10000">
+        </label>
+        <label>
+            Delay (s)
+            <input type="number" id="delay" value="1" min="0" step="0.1">
+        </label>
+        <button id="start">Start Stream</button>
+        <button id="stop" disabled>Stop</button>
+        <button id="clear">Clear</button>
+    </div>
+
+    <div id="status">Ready.</div>
+    <div id="events"></div>
+
+    <script>
+        const startBtn = document.getElementById('start');
+        const stopBtn  = document.getElementById('stop');
+        const clearBtn = document.getElementById('clear');
+        const statusEl = document.getElementById('status');
+        const eventsEl = document.getElementById('events');
+        let controller = null;
+
+        function setStatus(msg) { statusEl.textContent = msg; }
+
+        function addEvent(text, cls = '') {
+            const div = document.createElement('div');
+            div.className = 'event ' + cls;
+            div.textContent = text;
+            eventsEl.appendChild(div);
+            eventsEl.scrollTop = eventsEl.scrollHeight;
+        }
+
+        clearBtn.addEventListener('click', () => { eventsEl.innerHTML = ''; });
+
+        startBtn.addEventListener('click', async () => {
+            const chunks = document.getElementById('chunks').value;
+            const delay  = document.getElementById('delay').value;
+            const url = `/public/completions?chunks=${chunks}&delay=${delay}`;
+
+            startBtn.disabled = true;
+            stopBtn.disabled = false;
+            eventsEl.innerHTML = '';
+            setStatus(`Connecting to ${url} ...`);
+            addEvent(`→ POST ${url}`, 'meta');
+
+            const startTime = performance.now();
+            controller = new AbortController();
+
+            try {
+                const resp = await fetch(url, {
+                    method: 'POST',
+                    signal: controller.signal,
+                });
+
+                if (!resp.ok) {
+                    addEvent(`✗ HTTP ${resp.status} ${resp.statusText}`, 'error');
+                    setStatus(`Error: HTTP ${resp.status}`);
+                    return;
+                }
+
+                setStatus(`Connected (HTTP ${resp.status}). Streaming...`);
+
+                const reader = resp.body.getReader();
+                const decoder = new TextDecoder();
+                let buffer = '';
+                let count = 0;
+
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+
+                    buffer += decoder.decode(value, { stream: true });
+
+                    const lines = buffer.split('\n');
+                    buffer = lines.pop(); // keep incomplete line
+
+                    for (const line of lines) {
+                        if (line.startsWith('data: ')) {
+                            count++;
+                            const jsonStr = line.slice(6);
+                            try {
+                                const data = JSON.parse(jsonStr);
+                                if (data.done) {
+                                    addEvent(`✓ DONE — total chunks: ${data.total_chunks ?? count}`, 'done');
+                                } else {
+                                    addEvent(`#${count}  ${jsonStr}`);
+                                }
+                            } catch {
+                                addEvent(`#${count}  ${jsonStr}`);
+                            }
+                        }
+                    }
+                }
+
+                const elapsed = ((performance.now() - startTime) / 1000).toFixed(2);
+                setStatus(`Finished. ${count} events in ${elapsed}s`);
+            } catch (err) {
+                if (err.name === 'AbortError') {
+                    setStatus('Stream aborted by user.');
+                    addEvent('✗ Aborted', 'error');
+                } else {
+                    setStatus(`Network error: ${err.message}`);
+                    addEvent(`✗ ${err.name}: ${err.message}`, 'error');
+                }
+            } finally {
+                startBtn.disabled = false;
+                stopBtn.disabled = true;
+                controller = null;
+            }
+        });
+
+        stopBtn.addEventListener('click', () => {
+            if (controller) controller.abort();
+        });
+    </script>
+</body>
+</html>

--- a/containers/python-fastapi-stream/requirements.txt
+++ b/containers/python-fastapi-stream/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.6
+uvicorn[standard]==0.34.0


### PR DESCRIPTION
## Summary

This PR adds a simple FastAPI + SSE example to help debug potential network issues.

It's deployed using the Scaleway CLI:

```bash
$ scw container deploy
```

(which builds and deploys)

## Checklist

- [ ] I have reviewed this myself.
- [ ] I have attached a README to my example. You can use [this template](../docs/templates/readme-example-template.md) as reference.
- [ ] I have updated the project README to link my example.

## Details
